### PR TITLE
fix routing

### DIFF
--- a/config/build/buildWebpackConfig.ts
+++ b/config/build/buildWebpackConfig.ts
@@ -15,6 +15,7 @@ export function buildWebpackConfig(options: BuildOptions): webpack.Configuration
       filename: '[name].[contenthash].js',
       path: patchs.build,
       clean: true,
+      publicPath: '/',
     },
     plugins: buildPlugins(options),
     module: {


### PR DESCRIPTION
добавил параметр `publicPath: '/'` в настройки webpack, чтобы все ресурсы искались относительно корня, а не текущего URL