### PR TITLE
add search api

### DIFF
--- a/src/UIKit/PosterModal/PosterModal.tsx
+++ b/src/UIKit/PosterModal/PosterModal.tsx
@@ -2,11 +2,11 @@ import { DialogContent, IconButton } from '@mui/material';
 import Dialog from '@mui/material/Dialog';
 import ClearIcon from '@mui/icons-material/Clear';
 import { useTheme } from '@mui/material/styles';
-import { IPoster } from '../../api/apiTypes';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
 import { useEffect, useState } from 'react';
 import modalStyles from './modalStyles';
+import { IPoster } from '../../types/movieTypes';
 
 export const PosterModal = ({
   open,

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,20 +1,20 @@
+import { IMovieDiscover, MovieDetails } from '../types/movieTypes';
+import { ISearchParams, TSearchEndpoint, TSearchResponse } from './apiTypes/apiSearchTypes';
 import {
   IGetMoviesListParams,
-  TEndpoint,
+  TMovieEndpoint,
   IResponseList,
-  IMovie,
   IGetMovieParams,
-  IEndpointTypeMap,
-  MovieDetails,
-} from './apiTypes';
+  IMovieEndpointTypeMap,
+} from './apiTypes/apiTypes';
 import { apiTMDB } from './base';
 
 //схема - https://developer.themoviedb.org/reference/discover-movie
 export async function getMovieList({ params }: IGetMoviesListParams = {}): Promise<
-  IResponseList<IMovie[]>
+  IResponseList<IMovieDiscover[]>
 > {
   try {
-    const response = await apiTMDB.get<IResponseList<IMovie[]>>('discover/movie', {
+    const response = await apiTMDB.get<IResponseList<IMovieDiscover[]>>('discover/movie', {
       params,
     });
     return response.data;
@@ -27,21 +27,21 @@ export async function getMovieList({ params }: IGetMoviesListParams = {}): Promi
 //схема - https://developer.themoviedb.org/reference/movie-details
 // Перегрузка функции. Применена потому что нужно получать разные типы с эндпоинтом и без
 export async function getMovie(id: IGetMovieParams): Promise<MovieDetails>;
-export async function getMovie<E extends TEndpoint>({
+export async function getMovie<E extends TMovieEndpoint>({
   id,
   endpoint,
   params,
-}: IGetMovieParams): Promise<IEndpointTypeMap[E]>;
+}: IGetMovieParams): Promise<IMovieEndpointTypeMap[E]>;
 
-export async function getMovie<E extends TEndpoint>({
+export async function getMovie<E extends TMovieEndpoint>({
   id,
   endpoint,
   params,
-}: IGetMovieParams): Promise<IEndpointTypeMap[E]> {
+}: IGetMovieParams): Promise<IMovieEndpointTypeMap[E]> {
   const currentEndpoint = `movie/${id}${endpoint ? `/${endpoint}` : ''}`;
 
   try {
-    const response = await apiTMDB.get<IEndpointTypeMap[E]>(currentEndpoint, {
+    const response = await apiTMDB.get<IMovieEndpointTypeMap[E]>(currentEndpoint, {
       params,
     });
     return response.data;
@@ -50,3 +50,22 @@ export async function getMovie<E extends TEndpoint>({
     throw error;
   }
 }
+
+export async function getSearch<E extends TSearchEndpoint>({
+  endpoint,
+  params,
+}: ISearchParams<E>): Promise<TSearchResponse<E>> {
+  const currentEndpoint = `search/${endpoint}`;
+
+  try {
+    const response = await apiTMDB.get<TSearchResponse<E>>(currentEndpoint, {
+      params,
+    });
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+}
+
+//TODO исправить типы для getMovieList и getMovie по типу getSearch

--- a/src/api/apiTypes/apiSearchTypes.ts
+++ b/src/api/apiTypes/apiSearchTypes.ts
@@ -1,0 +1,87 @@
+import { IMovieDiscover } from '../../types/movieTypes';
+import {
+  ICollection,
+  ICompany,
+  IKeyword,
+  ISearchMulti,
+  ISearchPerson,
+  ISearchTv,
+} from '../../types/searchTypes';
+import { IResponseList } from './apiTypes';
+
+export interface ISearchParams<E extends TSearchEndpoint> {
+  endpoint: E;
+  params: TSearchParams<E>;
+}
+
+export type TSearchEndpoint =
+  | 'collection'
+  | 'company'
+  | 'keyword'
+  | 'movie'
+  | 'multi'
+  | 'person'
+  | 'tv';
+
+type SearchParamsMap = {
+  collection: {
+    query: string;
+    include_adult?: boolean;
+    language?: string;
+    page?: number;
+    region?: string;
+  };
+  company: {
+    query: string;
+    page?: number;
+  };
+  keyword: {
+    query: string;
+    page?: number;
+  };
+  movie: {
+    query: string;
+    include_adult?: boolean;
+    language?: string;
+    primary_release_year?: number;
+    page?: number;
+    region?: string;
+    year?: number;
+  };
+  multi: {
+    query: string;
+    include_adult?: boolean;
+    language?: string;
+    page?: number;
+  };
+  person: {
+    query: string;
+    include_adult?: boolean;
+    language?: string;
+    page?: number;
+  };
+  tv: {
+    query: string;
+    first_air_date_year?: number;
+    include_adult?: boolean;
+    language?: string;
+    page?: number;
+  };
+};
+
+// Тип для параметров поиска в зависимости от эндпоинта
+export type TSearchParams<E extends keyof SearchParamsMap> = SearchParamsMap[E];
+
+// Определяем типы ответов для каждого эндпоинта
+type TSearchResponseMap = {
+  movie: IResponseList<IMovieDiscover[]>;
+  collection: IResponseList<ICollection[]>;
+  company: IResponseList<ICompany[]>;
+  keyword: IResponseList<IKeyword[]>;
+  multi: IResponseList<ISearchMulti[]>;
+  person: IResponseList<ISearchPerson[]>;
+  tv: IResponseList<ISearchTv[]>;
+};
+
+// Тип для ответа на запрос поиска в зависимости от эндпоинта
+export type TSearchResponse<E extends keyof TSearchResponseMap> = TSearchResponseMap[E];

--- a/src/api/apiTypes/apiTypes.ts
+++ b/src/api/apiTypes/apiTypes.ts
@@ -1,0 +1,26 @@
+import { IAuthorDetails, ICredits, IImage, ILists, IRelease } from '../../types/movieTypes';
+
+export interface IResponseList<T> {
+  page: number;
+  results: T;
+  total_results: number;
+  total_pages: number;
+}
+export interface IMovieEndpointTypeMap {
+  reviews: IResponseList<IAuthorDetails[]>;
+  credits: ICredits;
+  release_dates: IRelease;
+  images: IImage[];
+  lists?: ILists;
+}
+
+export type TMovieEndpoint = 'release_dates' | 'credits' | 'reviews' | 'images' | 'lists';
+
+export interface IGetMoviesListParams {
+  params?: { [key: string]: number | string };
+}
+
+export interface IGetMovieParams extends IGetMoviesListParams {
+  id: number | string;
+  endpoint?: TMovieEndpoint;
+}

--- a/src/components/carousel/Carousel.tsx
+++ b/src/components/carousel/Carousel.tsx
@@ -6,12 +6,13 @@ import RemoveRedEyeIcon from '@mui/icons-material/RemoveRedEye';
 import StarsIcon from '@mui/icons-material/Stars';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import { getMovieList } from '../../api/api';
-import { IMovie, IResponseList } from '../../api/apiTypes';
+import { IResponseList } from '../../api/apiTypes/apiTypes';
 import { Link as RouterLink } from 'react-router-dom';
 import { useTheme } from '@mui/material/styles';
 import createCarouselStyles from './createCarouselStyles';
+import { IMovieDiscover } from '../../types/movieTypes';
 export const Carousel = () => {
-  const [movieList, setMovieList] = useState<IResponseList<IMovie[]>>();
+  const [movieList, setMovieList] = useState<IResponseList<IMovieDiscover[]>>();
 
   const theme = useTheme();
   const styles = createCarouselStyles(theme);

--- a/src/components/movieItem/MovieItem.tsx
+++ b/src/components/movieItem/MovieItem.tsx
@@ -2,10 +2,10 @@ import { Box, CardMedia, IconButton, Rating, Theme, Typography, useTheme } from 
 import Card from '@mui/material/Card';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import CommentIcon from '@mui/icons-material/Comment';
-import { IMovie } from '../../api/apiTypes';
+import { IMovieDiscover } from '../../types/movieTypes';
 
 interface MovieListProps {
-  movie: IMovie;
+  movie: IMovieDiscover;
 }
 const createStyles = (theme: Theme) => ({
   card: {

--- a/src/components/posterCard/PosterCard.tsx
+++ b/src/components/posterCard/PosterCard.tsx
@@ -2,9 +2,9 @@ import { Grid, IconButton, Tooltip } from '@mui/material';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import StarsIcon from '@mui/icons-material/Stars';
 import RemoveRedEyeIcon from '@mui/icons-material/RemoveRedEye';
-import { MovieDetails } from '../../api/apiTypes';
 import { useState } from 'react';
 import { PosterModal } from '../../UIKit/PosterModal/PosterModal';
+import { MovieDetails } from '../../types/movieTypes';
 
 interface PosterProps {
   movie: MovieDetails;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,3 +10,23 @@ export const API_PARAMS = {
   PAGE: 'page',
   APPEND: 'append_to_response',
 };
+
+export const API_SEARCH_ENDPOINTS = {
+  MOVIE: 'movie',
+  COLLECTION: 'collection',
+  COMPANY: 'company',
+  KEYWORD: 'keyword',
+  PERSON: 'person',
+  TV: 'tv',
+} as const;
+
+export const API_SEARCH_PARAMS = {
+  QUERY: 'query',
+  INCLUDE_ADULT: 'include_adult',
+  LANGUAGE: 'language',
+  PAGE: 'page',
+  REGION: 'region',
+  PRIMARY_RELEASE_YEAR: 'primary_release_year',
+  YEAR: 'year',
+  FIRST_AIR_DATE_YEAR: 'first_air_date_year',
+} as const;

--- a/src/pages/FilmPage/FilmPage.tsx
+++ b/src/pages/FilmPage/FilmPage.tsx
@@ -1,6 +1,5 @@
 import { useParams } from 'react-router-dom';
 import { Button, Grid, Typography } from '@mui/material';
-import { MovieDetails } from '../../api/apiTypes';
 import { useEffect, useState } from 'react';
 import { getMovie } from '../../api/api';
 import { PosterCard } from '../../components/posterCard/PosterCard';
@@ -8,6 +7,7 @@ import { MovieDesc } from './components/MovieDesc';
 import { MovieReviews } from './components/MovieReviews';
 import { API_PARAMS, MOVIE_ENDPOINTS } from '../../constants';
 import { LabelButton } from '../../UIKit/LabelButton/LabelButton';
+import { MovieDetails } from '../../types/movieTypes';
 
 const LABELS = ['cast', 'crew', 'details', 'genres', 'releases'];
 const PARAMS = [

--- a/src/pages/FilmPage/components/MovieDesc.tsx
+++ b/src/pages/FilmPage/components/MovieDesc.tsx
@@ -1,5 +1,5 @@
 import { Box, Typography, useTheme } from '@mui/material';
-import { MovieDetails } from '../../../api/apiTypes';
+import { MovieDetails } from '../../../types/movieTypes';
 
 interface IMovieDesc {
   movie: MovieDetails;

--- a/src/pages/FilmPage/components/MovieReviews.tsx
+++ b/src/pages/FilmPage/components/MovieReviews.tsx
@@ -1,6 +1,6 @@
 import { Button, Grid, Rating, Typography } from '@mui/material';
-import { MovieDetails } from '../../../api/apiTypes';
 import Avatar from '../../../assets/nophoto.png';
+import { MovieDetails } from '../../../types/movieTypes';
 
 interface IMovieReviews {
   movie: MovieDetails;

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Carousel } from '../../components/carousel/Carousel';
 import { MovieItem } from '../../components/movieItem/MovieItem';
-import { IMovie, IResponseList } from '../../api/apiTypes';
 import { getMovieList } from '../../api/api';
+import { IResponseList } from '../../api/apiTypes/apiTypes';
+import { IMovieDiscover } from '../../types/movieTypes';
 
 export const MainPage = () => {
-  const [movieList, setMovieList] = useState<IResponseList<IMovie[]>>();
+  const [movieList, setMovieList] = useState<IResponseList<IMovieDiscover[]>>();
 
   useEffect(() => {
     getMovieList().then((data) => setMovieList(data));

--- a/src/types/movieTypes.ts
+++ b/src/types/movieTypes.ts
@@ -1,20 +1,7 @@
-export interface IResponseList<T> {
-  page: number;
-  results: T;
-  total_results: number;
-  total_pages: number;
-}
-export interface IEndpointTypeMap {
-  reviews: IResponseList<IAuthorDetails[]>;
-  credits: ICredits;
-  release_dates: IRelease;
-  images: IImage[];
-  lists?: ILists;
-}
+import { IResponseList } from '../api/apiTypes/apiTypes';
 
-export type TEndpoint = 'release_dates' | 'credits' | 'reviews' | 'images' | 'lists';
-
-export interface IMovie {
+//discover
+export interface IMovieDiscover {
   adult: boolean;
   backdrop_path: string;
   genre_ids: number[];
@@ -31,6 +18,7 @@ export interface IMovie {
   vote_count: number;
 }
 
+//movie
 export interface MovieDetails {
   adult: boolean;
   backdrop_path: string;
@@ -79,69 +67,7 @@ export interface MovieDetails {
   images?: IImage;
   lists?: IResponseList<ILists[]>;
 }
-export interface ILists {
-  results: IResults[];
-}
-export interface IResults {
-  description: string;
-  favorite_count: number;
-  id: number;
-  item_count: number;
-  iso_639_1: string;
-  list_type: string;
-  name: string;
-  poster_path: string;
-}
-export interface IImage {
-  backdrops: IBackdrops[];
-  logos: ILogos[];
-  posters: IPoster[];
-  id: number;
-}
-export interface IBackdrops {
-  aspect_ratio: number;
-  height: number;
-  iso_639_1: string;
-  file_path: string;
-  vote_average: number;
-  vote_count: number;
-  width: number;
-}
-export interface ILogos {
-  aspect_ratio: number;
-  height: number;
-  iso_639_1: string;
-  file_path: string;
-  vote_average: number;
-  vote_count: number;
-  width: number;
-}
-export interface IPoster {
-  aspect_ratio: number;
-  height: number;
-  iso_639_1: string;
-  file_path: string;
-  vote_average: number;
-  vote_count: number;
-  width: number;
-}
-export interface IRelease {
-  results: IReleaseDates[];
-}
 
-export interface IReleaseDates {
-  iso_3166_1: string;
-  release_dates: IReleaseDetail[];
-}
-
-export interface IReleaseDetail {
-  certification: string;
-  descriptors: string[];
-  iso_639_1: string;
-  note: string;
-  release_date: string;
-  type: number;
-}
 export interface IAuthorDetails {
   author: string;
   author_details: IDetails;
@@ -151,6 +77,7 @@ export interface IAuthorDetails {
   id: string;
   url: string;
 }
+
 export interface IDetails {
   avatar_path: null;
   name: string;
@@ -158,7 +85,7 @@ export interface IDetails {
   username: string;
 }
 
-interface ICredits {
+export interface ICredits {
   id: number;
   cast: CastMember[];
   crew: CrewMember[];
@@ -193,13 +120,68 @@ interface CrewMember {
   job: string;
 }
 
-export interface IGetMoviesListParams {
-  params?: { [key: string]: number | string };
+export interface IRelease {
+  results: IReleaseDates[];
 }
 
-export interface IGetMovieParams extends IGetMoviesListParams {
-  id: number | string;
-  endpoint?: TEndpoint;
+export interface IReleaseDates {
+  iso_3166_1: string;
+  release_dates: IReleaseDetail[];
 }
 
-// слишком много типов тут выходит. нужно разделить
+export interface IReleaseDetail {
+  certification: string;
+  descriptors: string[];
+  iso_639_1: string;
+  note: string;
+  release_date: string;
+  type: number;
+}
+
+export interface IImage {
+  backdrops: IBackdrops[];
+  logos: ILogos[];
+  posters: IPoster[];
+  id: number;
+}
+export interface IBackdrops {
+  aspect_ratio: number;
+  height: number;
+  iso_639_1: string;
+  file_path: string;
+  vote_average: number;
+  vote_count: number;
+  width: number;
+}
+export interface ILogos {
+  aspect_ratio: number;
+  height: number;
+  iso_639_1: string;
+  file_path: string;
+  vote_average: number;
+  vote_count: number;
+  width: number;
+}
+export interface IPoster {
+  aspect_ratio: number;
+  height: number;
+  iso_639_1: string;
+  file_path: string;
+  vote_average: number;
+  vote_count: number;
+  width: number;
+}
+
+export interface ILists {
+  results: IResults[];
+}
+export interface IResults {
+  description: string;
+  favorite_count: number;
+  id: number;
+  item_count: number;
+  iso_639_1: string;
+  list_type: string;
+  name: string;
+  poster_path: string;
+}

--- a/src/types/searchTypes.ts
+++ b/src/types/searchTypes.ts
@@ -1,0 +1,76 @@
+import { IMovieDiscover } from './movieTypes';
+
+export interface ICollection {
+  adult: boolean;
+  backdrop_path: string;
+  id: number;
+  name: string;
+  original_language: string;
+  original_name: string;
+  overview: string;
+  poster_path: string;
+}
+
+export interface ICompany {
+  id: number;
+  logo_path: string | null;
+  name: string;
+  origin_country: string;
+}
+
+export interface IKeyword {
+  id: number;
+  name: string;
+}
+
+// универсальный тип для фильмов и сериалов
+export interface ISearchMulti {
+  adult: boolean;
+  backdrop_path: string | null;
+  id: number;
+  title?: string; // Название для фильмов
+  name?: string; // Название для сериалов
+  original_language: string;
+  original_title?: string; // Оригинальное название для фильмов
+  original_name?: string; // Оригинальное название для сериалов
+  overview: string;
+  poster_path: string | null;
+  media_type: 'movie' | 'tv';
+  genre_ids: number[];
+  popularity: number;
+  release_date?: string; // Дата выхода для фильмов
+  first_air_date?: string; // Дата первого выхода для сериалов
+  video: boolean;
+  vote_average: number;
+  vote_count: number;
+  origin_country?: string[]; // Страны производства для сериалов
+}
+
+export interface ISearchPerson {
+  adult: boolean;
+  gender: number;
+  id: number;
+  known_for_department: string;
+  name: string;
+  original_name: string;
+  popularity: number;
+  profile_path: string;
+  known_for: IMovieDiscover[];
+}
+
+export interface ISearchTv {
+  adult: boolean;
+  backdrop_path: string;
+  genre_ids: number[];
+  id: number;
+  origin_country: string[];
+  original_language: string;
+  original_name: string;
+  overview: string;
+  popularity: number;
+  poster_path: string;
+  first_air_date: string;
+  name: string;
+  vote_average: number;
+  vote_count: number;
+}


### PR DESCRIPTION
добавил метод [search](https://developer.themoviedb.org/reference/search-collection). Добавил сразу все возможные эндпоинты и типы к ним.

Пример:
```
    getSearch({
      endpoint: API_SEARCH_ENDPOINTS.MOVIE,
      params: { [API_SEARCH_PARAMS.QUERY]: "blade runner" },
    }).then((data) => setMovieList(data));
    
```

 Отрефакторил типы: теперь в scr есть папка types в которой храним типы сущностей(ответов от сервера и т.д.). 
 Все типы касающиеся запросов теперь в `api/apiTypes`