### PR TITLE
redirect in vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+    "rewrites": [
+        {
+            "source": "/(.*)",
+            "destination": "/"
+        }
+    ]
+}


### PR DESCRIPTION
Исправил ошибку 404 которая возникала на vercel если обновить страницу находясь не на "/".
Ошибка возникала, потому что сервер Vercel не находит файлы для маршрутов SPA при обновлении страницы; 
Решение — настроил редиректы в `vercel.json`, чтобы все запросы перенаправлялись на `index.html`