### PR TITLE
add error snackbar

### DIFF
--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -9,3 +9,14 @@ export const apiTMDB = axios.create({
     Authorization: `Bearer ${apiKey}`,
   },
 });
+
+export const setupAxiosInterceptors = (showError: (message: string) => void) => {
+  apiTMDB.interceptors.response.use(
+    (response) => response,
+    (error) => {
+      const message = error.response?.data?.status_message || 'Network error';
+      showError(message);
+      return Promise.reject(error);
+    },
+  );
+};

--- a/src/layouts/Root.tsx
+++ b/src/layouts/Root.tsx
@@ -4,17 +4,20 @@ import { ThemeProvider } from '@mui/material/styles';
 import { theme } from '../providers/theme/theme';
 import { ImageConfigProvider } from '../providers/ImageConfigProvider/ImageConfigProvider';
 import { ErrorBoundary } from '../providers/ErrorBoundary/ErrorBoundary';
+import { SnackbarProvider } from '../providers/SnackbarProvider/SnackbarProvider';
 
 export const Root = () => {
   return (
     <ErrorBoundary>
-      <ImageConfigProvider>
-        <ThemeProvider theme={theme}>
-          <BrowserRouter>
-            <Router />
-          </BrowserRouter>
-        </ThemeProvider>
-      </ImageConfigProvider>
+      <SnackbarProvider>
+        <ImageConfigProvider>
+          <ThemeProvider theme={theme}>
+            <BrowserRouter>
+              <Router />
+            </BrowserRouter>
+          </ThemeProvider>
+        </ImageConfigProvider>
+      </SnackbarProvider>
     </ErrorBoundary>
   );
 };

--- a/src/providers/SnackbarProvider/SnackbarContext.ts
+++ b/src/providers/SnackbarProvider/SnackbarContext.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+
+export interface ErrorContextType {
+  open: boolean;
+  errorMessage: string;
+  showError: (message: string) => void;
+  closeError: () => void;
+}
+
+export const SnackbarContext = createContext<ErrorContextType | undefined>(undefined);

--- a/src/providers/SnackbarProvider/SnackbarProvider.tsx
+++ b/src/providers/SnackbarProvider/SnackbarProvider.tsx
@@ -1,0 +1,33 @@
+import { FC, ReactNode, useState, useEffect } from 'react';
+import { SnackbarContext } from './SnackbarContext';
+import { Alert, Snackbar } from '@mui/material';
+import { setupAxiosInterceptors } from '../../api/base';
+
+export const SnackbarProvider: FC<{ children: ReactNode }> = ({ children }) => {
+  const [open, setOpen] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const showError = (message: string) => {
+    setErrorMessage(message);
+    setOpen(true);
+  };
+
+  const closeError = () => {
+    setOpen(false);
+  };
+
+  useEffect(() => {
+    setupAxiosInterceptors(showError);
+  }, []);
+
+  return (
+    <SnackbarContext.Provider value={{ open, errorMessage, showError, closeError }}>
+      {children}
+      <Snackbar open={open} autoHideDuration={5000} onClose={closeError}>
+        <Alert onClose={closeError} severity="error" sx={{ width: '100%' }}>
+          {errorMessage}
+        </Alert>
+      </Snackbar>
+    </SnackbarContext.Provider>
+  );
+};


### PR DESCRIPTION
Добавил провайдер снэкбара для отображения ошибок API пользователю. Например, если в запросе передали несуществующую страницу:
![Screenshot 2024-11-04 122925](https://github.com/user-attachments/assets/cb9ce3f8-a1de-46a3-9a17-76c6fcbda7a0)

Я добавил интерсептор в Axios и обернул приложение в SnackbarProvider. Теперь при использовании apiTMDB ошибки будут автоматически обрабатываться интерсептором, и сообщения об ошибках будут отображаться в снэкбаре.
